### PR TITLE
 Add form element filtering by survey type

### DIFF
--- a/src/fobi/views/function_based.py
+++ b/src/fobi/views/function_based.py
@@ -440,7 +440,7 @@ def edit_form_entry(request, form_entry_id, theme=None, template_name=None):
     """
     try:
         form_entry = FormEntry.objects.get(pk=form_entry_id)
-        type = form_entry.surveyformentry.type
+        survey_type = form_entry.surveyformentry.type
 
         # Come back to this when working out permissioning system
 
@@ -550,13 +550,13 @@ def edit_form_entry(request, form_entry_id, theme=None, template_name=None):
         sort_by_value=SORT_PLUGINS_BY_VALUE,
     )
 
-    if type == 'observational':
+    if survey_type == 'observational':
         try:
             user_form_element_plugins.pop('Intercept')
         except KeyError:
             pass
 
-    elif type == 'intercept':
+    elif survey_type == 'intercept':
         try:
             user_form_element_plugins.pop('Observational')
         except KeyError:

--- a/src/fobi/views/function_based.py
+++ b/src/fobi/views/function_based.py
@@ -440,6 +440,7 @@ def edit_form_entry(request, form_entry_id, theme=None, template_name=None):
     """
     try:
         form_entry = FormEntry.objects.get(pk=form_entry_id)
+        type = form_entry.surveyformentry.type
 
         # Come back to this when working out permissioning system
 
@@ -546,8 +547,21 @@ def edit_form_entry(request, form_entry_id, theme=None, template_name=None):
     # List of form element plugins allowed to user
     user_form_element_plugins = get_user_form_element_plugins_grouped(
         request.user,
-        sort_by_value=SORT_PLUGINS_BY_VALUE
+        sort_by_value=SORT_PLUGINS_BY_VALUE,
     )
+
+    if type == 'observational':
+        try:
+            user_form_element_plugins.pop('Intercept')
+        except KeyError:
+            pass
+
+    elif type == 'intercept':
+        try:
+            user_form_element_plugins.pop('Observational')
+        except KeyError:
+            pass
+
     # List of form handler plugins allowed to user
     user_form_handler_plugins = get_user_form_handler_plugins(
         request.user,


### PR DESCRIPTION
Allows observational and intercept surveys to have different form elements! I don't love doing this Just Spaces-specific work in this repo, but I don't see a reasonably simple way to bring it into just-spaces without rewriting the views. 