### PR TITLE
Add check for preview vs. running surveys

### DIFF
--- a/src/fobi/contrib/themes/foundation5/templates/foundation5/edit_form_entry_ajax.html
+++ b/src/fobi/contrib/themes/foundation5/templates/foundation5/edit_form_entry_ajax.html
@@ -1,9 +1,9 @@
 {% load i18n fobi_tags %}
 
-<h3>{% trans "Edit form" %}</h3>
+<h3>{% trans "Edit" %} {{form_entry.surveyformentry.name}}</h3>
 
 <div class="row">
-    
+
 
     <div class="columns">
 
@@ -19,7 +19,7 @@
 
         <div class="content active" id="tab-form-elements">
 
-          
+
             <!-- Form element plugins -->
             <div>
               <h4 id="form_elements">{% trans "Add elements to your form" %}</h4>
@@ -202,7 +202,7 @@
         </div><!-- tab-form-service -->
 
       </div><!-- tabs-content -->
-        
+
     </div><!-- columns -->
 
 </div><!-- row -->

--- a/src/fobi/templates/fobi/generic/view_form_entry_ajax.html
+++ b/src/fobi/templates/fobi/generic/view_form_entry_ajax.html
@@ -3,7 +3,17 @@
 {% load i18n %}
 
 {% block form_page_title %}
-{% if fobi_form_title %}{{ fobi_form_title }}{% else %}{% trans "View form" %}{% endif %}
+  {% if form_entry.surveyformentrypublished %}
+  Run
+  {% else %}
+  Preview 
+  {% endif %}
+
+  {% if form_entry.name %}
+    {{ form_entry.name }}
+  {% else %}
+    {% trans "View form" %}
+  {% endif %}
 {% endblock form_page_title %}
 
 {% block form_primary_button_text %}{% if fobi_form_submit_button_text %}{{ fobi_form_submit_button_text }}{% else %}{% trans "Submit" %}{% endif %}{% endblock %}


### PR DESCRIPTION
Modifies templates to show `Preview <survey name>` if unpublished and `Run <survey name>` if published. Data handling will be handled in https://github.com/datamade/just-spaces/pull/107